### PR TITLE
Recreate php-fpm-exporter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine
+
+COPY configs/binaries/php-fpm-prometheus /
+
+RUN chmod +x /php-fpm-prometheus
+
+EXPOSE 9102
+
+CMD ["/php-fpm-prometheus", "-addr", "0.0.0.0:9091", "-status-url", "http://127.0.0.1/status"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# php-fpm-exporter

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# php-fpm-exporter


### PR DESCRIPTION
I'm just recreating what there is. Look at the image we use this appears right. Even the weird `EXPOSE` on a port we're not using

Output from `docker image inspect superbalist/php-fpm-exporter:1.0.0`
```
        "Config": {
            "Hostname": "e1ede117fb1e",
            "Domainname": "",
            "User": "",
            "AttachStdin": false,
            "AttachStdout": false,
            "AttachStderr": false,
            "ExposedPorts": {
                "9102/tcp": {}
            },
            "Tty": false,
            "OpenStdin": false,
            "StdinOnce": false,
            "Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
            ],
            "Cmd": [
                "/php-fpm-prometheus",
                "-addr",
                "0.0.0.0:9091",
                "-status-url",
                "http://127.0.0.1/status"
            ],
            "ArgsEscaped": true,
            "Image": "sha256:8b1d9d39e13bb142caf80093d39b8e10a4e954b319bfa09503085743c7bb75e3",
            "Volumes": null,
            "WorkingDir": "",
            "Entrypoint": null,
            "OnBuild": [],
            "Labels": {}
        },
```
